### PR TITLE
[Fix] 레이아웃 export 오류 해결

### DIFF
--- a/src/Styles/LayoutStyle.jsx
+++ b/src/Styles/LayoutStyle.jsx
@@ -1,11 +1,4 @@
-import React from 'react';
-import { styled } from 'styled-components';
-
-const LayoutStyle = () => {
-  return <SLayoutStyle></SLayoutStyle>;
-};
-
-export default LayoutStyle;
+import styled from 'styled-components';
 
 const SLayoutStyle = styled.div`
   margin: 0 auto;
@@ -13,3 +6,11 @@ const SLayoutStyle = styled.div`
   height: 829px;
   background-color: white;
 `;
+
+// const SLayout = styled.div`
+//   ${SLayoutStyle}
+// `;
+
+//<Button onError={username !== userId}></Button>
+
+export { SLayoutStyle };


### PR DESCRIPTION
수정 전 코드
```
import React from 'react';
import { styled } from 'styled-components';

const LayoutStyle = () => {
  return <SLayoutStyle></SLayoutStyle>;
};

export default LayoutStyle;

const SLayoutStyle = styled.div`
  margin: 0 auto;
  width: 390px;
  height: 829px;
  background-color: white;
`;

```

수정 후 코드
```
import styled from 'styled-components';

const SLayoutStyle = styled.div`
  margin: 0 auto;
  width: 390px;
  height: 829px;
  background-color: white;
`;

// const SLayout = styled.div`
//   ${SLayoutStyle}
// `;

//<Button onError={username !== userId}></Button>

export { SLayoutStyle };

```
export할때 이렇게 해야 한다.