### PR TITLE
[Feat] 인풋 박스 구현 정상일때, disabled일때

### DIFF
--- a/src/Components/Common/InputBox.jsx
+++ b/src/Components/Common/InputBox.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { styled } from 'styled-components';
+
+const InputBox = props => {
+  return (
+    <SInputBox>
+      <label className="input-label" htmlFor="input-content">
+        {props.title}
+      </label>
+      <input disabled={props.disabled} id="input-content" type="text" placeholder={props.placeholder} />
+    </SInputBox>
+  );
+};
+
+export default InputBox;
+
+const SInputBox = styled.form`
+  width: 100%;
+  position: relative;
+  text-align: center;
+
+  #input-content {
+    width: 100%;
+    border-bottom: 1px solid #dbdbdb;
+    padding: 10px 0 5px 0;
+    text-align: left;
+    margin-top: 10px;
+    font-size: 14px;
+  }
+  #input-content:disabled {
+    border: none;
+  }
+  #input-content::placeholder {
+    color: var(--gray);
+  }
+
+  .input-label {
+    color: var(--deepgray);
+    font-size: 12px;
+    position: absolute;
+  }
+`;


### PR DESCRIPTION
- 인풋 박스 props로 `disabled, title, placeholder` 받습니다.
  - `disabled`: 인풋이지만 선택 안되게
  - `title`: 라벨 내용
  - `placeholder`: placeholder 내용