### PR TITLE
[Feat] API 모듈 분리 및 상태 관리용 recoil 업데이트

### DIFF
--- a/src/API/Comment.jsx
+++ b/src/API/Comment.jsx
@@ -1,0 +1,102 @@
+import { useRecoilValue } from 'recoil';
+import { Token } from '../Atom/atom';
+const URL = "https://api.mandarin.weniv.co.kr";
+
+const PutCommentAPI = async ({postId}, {comment}) => {
+	const getMyToken = useRecoilValue(Token);
+
+	try {
+		const req = {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"Authorization": "Bearer " + getMyToken
+			},
+			body: {
+				"comment": {
+					"content": {comment}
+				}
+			}
+		};
+
+		const response = await fetch(URL + "/post/:" + {postId} + "/comments", req);
+		
+		if (!response.ok)
+			throw new Error("댓글 작성 에러");
+
+		return await response.json();
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+const DeleteCommentAPI = async ({postId}, {commentId}) => {
+	const getMyToken = useRecoilValue(Token);
+
+	try {
+		const req = {
+			method: "DELETE",
+			headers: {
+				"Content-Type": "application/json",
+				"Authorization": "Bearer " + getMyToken
+			}
+		};
+
+		const response = await fetch(URL + "/post/:" + {postId} + "/comments/:" + {commentId}, req);
+		
+		if (!response.ok)
+			throw new Error("댓글 삭제 에러");
+
+		return await response.json();
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+const ReportCommentAPI = async ({postId}, {commentId}) => {
+	const getMyToken = useRecoilValue(Token);
+
+	try {
+		const req = {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"Authorization": "Bearer " + getMyToken
+			}
+		};
+
+		const response = await fetch(URL + "/post/:" + {postId} + "/comments/:" + {commentId} + "/report", req);
+		
+		if (!response.ok)
+			throw new Error("댓글 신고 에러");
+
+		return await response.json();
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+const GetCommentListAPI = async (postId) => {
+	const getMyToken = useRecoilValue(Token);
+
+	try {
+		const req = {
+			method: "GET",
+			headers: {
+				"Content-Type": "application/json",
+				"Authorization": "Bearer " + getMyToken
+			}
+		};
+
+		const response = await fetch(URL + "/post/:" + {postId} + "/comments", req);
+		
+		if (!response.ok)
+			throw new Error("댓글 리스트 가져오기 에러");
+
+		return await response.json();
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+export {PutCommentAPI, ReportCommentAPI, DeleteCommentAPI, GetCommentListAPI};

--- a/src/API/GetShowAPI.jsx
+++ b/src/API/GetShowAPI.jsx
@@ -1,0 +1,26 @@
+import { Show } from "../Atom/atom";
+import { useSetRecoilState } from "recoil";
+import { useRecoilValue } from "recoil";
+
+const GetShowAPI = async () => {
+	const setShow = useSetRecoilState(Show);
+	const getShow = useRecoilValue(Show);
+
+	try {
+	// while(true) {
+			const response = await fetch("http://openapi.seoul.go.kr:8088/774c79676c79686f31303566616f7871/json/culturalEventInfo/" + (getShow.length + 1) + "/" + (getShow.length + 1000));
+
+			if (!response.ok)
+				throw new Error("ERROR");
+			if (!response.length)
+				setShow({...getShow, ...response});
+
+		// }
+		return getShow;
+
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+export default GetShowAPI;

--- a/src/API/Image.jsx
+++ b/src/API/Image.jsx
@@ -1,0 +1,36 @@
+const URL = "https://api.mandarin.weniv.co.kr";
+
+const UploadImgAPI = async (body) => {
+	try {
+		const req = {
+			method: "POST",
+			headers: {
+				"Content-Type": "multipart/form-data"
+			},
+			body: JSON.stringify({ ...body })};
+
+		const response = await fetch(URL + "/image/uploadfile", req);
+		
+		if (!response.ok)
+			throw new Error("이미지 업로드 에러");
+
+		return await response.json();
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+const GetImgAPI = async (imgAddress) => {
+	try {
+		const response = await fetch(imgAddress);
+
+		if (!response.ok)
+			throw new Error("이미지 가져오기 에러");
+
+		return await response.json();
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+export {UploadImgAPI, GetImgAPI};

--- a/src/API/Like.jsx
+++ b/src/API/Like.jsx
@@ -1,0 +1,49 @@
+import { useRecoilValue } from 'recoil';
+import { Token } from '../Atom/atom';
+const URL = "https://api.mandarin.weniv.co.kr";
+
+const HeartPostAPI = async (postId) => {
+	const getMyToken = useRecoilValue(Token);
+
+	try {
+		const req = {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"Authorization": "Bearer " + getMyToken
+			}};
+
+		const response = await fetch(URL + "/post/:" + {postId} + "/heart", req);
+		
+		if (!response.ok)
+			throw new Error("게시글 좋아요 에러");
+
+		return await response.json();
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+const UnheartPostAPI = async (postId) => {
+	const getMyToken = useRecoilValue(Token);
+
+	try {
+		const req = {
+			method: "DELETE",
+			headers: {
+				"Content-Type": "application/json",
+				"Authorization": "Bearer " + getMyToken
+			}};
+
+		const response = await fetch(URL + "/post/:" + {postId} + "/unheart", req);
+		
+		if (!response.ok)
+			throw new Error("게시글 좋아요 에러");
+
+		return await response.json();
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+export {HeartPostAPI, UnheartPostAPI};

--- a/src/API/Post.jsx
+++ b/src/API/Post.jsx
@@ -1,0 +1,139 @@
+import { useRecoilValue } from 'recoil';
+import { Token } from '../Atom/atom';
+const URL = "https://api.mandarin.weniv.co.kr";
+
+const PostPostAPI = async (post) => {
+	const getMyToken = useRecoilValue(Token);
+
+	try {
+		const req = {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"Authorization": "Bearer " + getMyToken
+			},
+			body: JSON.stringify({ ...post })};
+
+		const response = await fetch(URL + "/post", req);
+		
+		if (!response.ok)
+			throw new Error("게시글 작성 에러");
+
+		return await response.json();
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+const GetUserPostAPI = async (accountName) => {
+	const getMyToken = useRecoilValue(Token);
+
+	try {
+		const req = {
+			method: "GET",
+			headers: {
+				"Content-Type": "application/json",
+				"Authorization": "Bearer " + getMyToken
+			}};
+
+		const response = await fetch(URL + "/post/:" + {accountName} + "/userpost", req);
+		
+		if (!response.ok)
+			throw new Error("사용자 게시글 목록 조회 에러");
+
+		return await response.json();
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+const GetPostDetailAPI = async (postId) => {
+	const getMyToken = useRecoilValue(Token);
+
+	try {
+		const req = {
+			method: "GET",
+			headers: {
+				"Content-Type": "application/json",
+				"Authorization": "Bearer " + getMyToken
+			}};
+
+		const response = await fetch(URL + "/post/:" + {postId}, req);
+		
+		if (!response.ok)
+			throw new Error("게시글 상세 조회 에러");
+
+		return await response.json();
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+const EditPostAPI = async ({newPost}, {postId}) => {
+	const getMyToken = useRecoilValue(Token);
+
+	try {
+		const req = {
+			method: "PUT",
+			headers: {
+				"Content-Type": "application/json",
+				"Authorization": "Bearer " + getMyToken
+			},
+			body: JSON.stringify({ ...newPost })};
+
+		const response = await fetch(URL + "/post/:" + {postId}, req);
+		
+		if (!response.ok)
+			throw new Error("게시글 수정 에러");
+
+		return await response.json();
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+const DeletePostAPI = async (postId) => {
+	const getMyToken = useRecoilValue(Token);
+
+	try {
+		const req = {
+			method: "DELETE",
+			headers: {
+				"Content-Type": "application/json",
+				"Authorization": "Bearer " + getMyToken
+			}};
+
+		const response = await fetch(URL + "/post/:" + {postId}, req);
+		
+		if (!response.ok)
+			throw new Error("게시글 삭제 에러");
+
+		return await response.json();
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+const ReportPostAPI = async (postId) => {
+	const getMyToken = useRecoilValue(Token);
+
+	try {
+		const req = {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"Authorization": "Bearer " + getMyToken
+			}};
+
+		const response = await fetch(URL + "/post/:" + {postId} + "/report", req);
+		
+		if (!response.ok)
+			throw new Error("게시글 신고 에러");
+
+		return await response.json();
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+export {PostPostAPI, GetPostDetailAPI, GetUserPostAPI, DeletePostAPI, ReportPostAPI, EditPostAPI};

--- a/src/API/Profile.jsx
+++ b/src/API/Profile.jsx
@@ -1,0 +1,72 @@
+import { useRecoilValue } from 'recoil';
+import { Token } from '../Atom/atom';
+const URL = "https://api.mandarin.weniv.co.kr";
+
+const GetMyProfileAPI = async () => {
+	const getMyToken = useRecoilValue(Token);
+
+	try {
+		const req = {
+			method: "GET",
+			headers: {
+				"Authorization": "Bearer " + getMyToken
+			}};
+
+		const response = await fetch(URL + "/user/myinfo", req);
+		
+		if (!response.ok)
+			throw new Error("프로필 정보 불러오기 에러");
+
+		return await response.json();
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+const EditProfileAPI = async (profile) => {
+	const getMyToken = useRecoilValue(Token);
+
+	try {
+		const req = {
+			method: "PUT",
+			headers: {
+				"Content-Type": "application/json",
+				"Authorization": "Bearer " + getMyToken
+			},
+			body: JSON.stringify({ ...profile })};
+
+		const response = await fetch(URL + "/user", req);
+		
+		if (!response.ok)
+			throw new Error("프로필 수정 에러");
+
+		return await response.json();
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+const GetOtherProfileAPI = async (accountName) => {
+	const getMyToken = useRecoilValue(Token);
+
+	try {
+		const req = {
+			method: "GET",
+			headers: {
+				"Content-Type": "application/json",
+				"Authorization": "Bearer " + getMyToken
+			}
+		};
+
+		const response = await fetch(URL + "/profile/:" + {accountName}, req);
+		
+		if (!response.ok)
+			throw new Error("다른 프로필 보기 에러");
+
+		return await response.json();
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+export {GetMyProfileAPI, GetOtherProfileAPI, EditProfileAPI};

--- a/src/API/User.jsx
+++ b/src/API/User.jsx
@@ -1,0 +1,114 @@
+import { useRecoilValue } from 'recoil';
+import { Token } from '../Atom/atom';
+const URL = "https://api.mandarin.weniv.co.kr";
+
+const SignUpAPI = async (body) => {
+	try {
+		const req = {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json"
+			},
+			body: JSON.stringify({ ...body })};
+
+		const response = await fetch(URL + "/user", req);
+		
+		if (!response.ok)
+			throw new Error("회원가입 에러");
+
+		return await response.json();
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+const LoginAPI = async (body) => {
+	try {
+		const req = {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json"
+			},
+			body: JSON.stringify({ ...body })};
+
+		const response = await fetch(URL + "/user/login", req);
+		
+		if (!response.ok)
+			throw new Error("로그인 에러");
+
+		return await response.json();
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+const IsValidEmailAPI = async (email) => {
+	try {
+		const req = {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json"
+			},
+			body: {
+				"user":{"accountname": {email}}
+			}
+		};
+
+		const response = await fetch(URL + "/user/emailvalid", req);
+		
+		if (!response.ok)
+			throw new Error("이메일 검증 에러");
+
+		return await response.json();
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+const IsValidAccountAPI = async (accountName) => {
+	try {
+		const req = {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json"
+			},
+			body: {
+				"user":{"accountname": {accountName}}
+			}
+		};
+
+		const response = await fetch(URL + "/user/accountnamevalid", req);
+		
+		if (!response.ok)
+			throw new Error("계정 검증 에러");
+
+		return await response.json();
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+const IsValidTokenAPI = async () => {
+	const getMyToken = useRecoilValue(Token);
+
+	try {
+		const req = {
+			method: "GET",
+			headers: {
+				"Content-Type": "application/json",
+				"Authorization": "Bearer " + getMyToken
+			}
+		};
+
+		const response = await fetch(URL + "/user/checktoken", req);
+		
+		if (!response.ok)
+			throw new Error("토큰 검증 에러");
+
+		return await response.json();
+	} catch (e) {
+		console.error(e);
+	}
+};
+
+export {SignUpAPI, LoginAPI, IsValidAccountAPI, IsValidEmailAPI, IsValidTokenAPI};

--- a/src/Atom/atom.jsx
+++ b/src/Atom/atom.jsx
@@ -1,2 +1,66 @@
-import { atom } from 'recoil';
-import { recoilPersist } from 'recoil-persist';
+import { atom } from "recoil";
+import { recoilPersist } from "recoil-persist";
+
+export const Token = atom({
+	key: "setToken",
+	default: "",
+});
+
+export const Show = atom({
+  key: "CultureShow",
+  default: {},
+})
+
+export const InterestTags = atom({
+	key: "setInterestTags",
+	default: {
+		"교육/체험": false,
+    "독주/독창회": false,
+    "무용": false,
+    "전시/미술": false,
+    "영화": false,
+    "축제": false,
+    "국악": false,
+    "콘서트": false,
+    "연극": false,
+    "뮤지컬/오페라": false,
+    "클래식": false,
+    "기타": false,
+	},
+});
+
+export const AreaTags = atom({
+	key: "setAreaTags",
+	default: {
+		"강남구": false,
+    "강동구": false,
+    "강북구": false,
+    "강서구": false,
+    "광진구": false,
+    "관악구": false,
+    "구로구	": false,
+    "금천구": false,
+    "노원구": false,
+    "도봉구": false,
+    "동대문구": false,
+    "동작구": false,
+    "마포구": false,
+    "서대문구": false,
+    "서초구": false,
+    "성동구": false,
+    "성북구": false,
+    "송파구": false,
+    "양천구": false,
+    "영등포구": false,
+    "용산구": false,
+    "은평구": false,
+    "종로구": false,
+    "중구": false,
+    "중랑구": false,
+	},
+});
+
+export const setPeriod = atom({
+	key: "setPeriod",
+	default: [0,0],
+})

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,14 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import { BrowserRouter } from 'react-router-dom';
+import { RecoilRoot } from 'recoil';
 
 const container = document.getElementById('root');
 const root = createRoot(container);
 root.render(
   <BrowserRouter>
+  <RecoilRoot>
     <App />
+  </RecoilRoot>
   </BrowserRouter>,
 );


### PR DESCRIPTION
- 감귤마켓 API 모듈 분리
  - body에 해당하는 부분, id들만 넘겨주면
  - response 결과를 return 해주게
- 공공데이터 API는 진행중
- recoil 사용 위해 `index.js`에 `RecoilRoot` 설정
- atom 변수 기본 설정