### PR TITLE
[Feat] 행사상세페이지 마크업 및 기능 구현

### DIFF
--- a/src/Assets/Icon/icon-share.svg
+++ b/src/Assets/Icon/icon-share.svg
@@ -1,7 +1,17 @@
-<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M14 6.66663C15.3807 6.66663 16.5 5.54734 16.5 4.16663C16.5 2.78591 15.3807 1.66663 14 1.66663C12.6193 1.66663 11.5 2.78591 11.5 4.16663C11.5 5.54734 12.6193 6.66663 14 6.66663Z" stroke="#767676" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M4 12.5C5.38071 12.5 6.5 11.3807 6.5 10C6.5 8.61929 5.38071 7.5 4 7.5C2.61929 7.5 1.5 8.61929 1.5 10C1.5 11.3807 2.61929 12.5 4 12.5Z" stroke="#767676" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M14 18.3334C15.3807 18.3334 16.5 17.2141 16.5 15.8334C16.5 14.4527 15.3807 13.3334 14 13.3334C12.6193 13.3334 11.5 14.4527 11.5 15.8334C11.5 17.2141 12.6193 18.3334 14 18.3334Z" stroke="#767676" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M6.1582 11.2583L11.8499 14.575" stroke="#767676" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M11.8415 5.42505L6.1582 8.74172" stroke="#767676" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_b_401_390)">
+<path d="M16.8 8C18.4569 8 19.8 6.65685 19.8 5C19.8 3.34315 18.4569 2 16.8 2C15.1432 2 13.8 3.34315 13.8 5C13.8 6.65685 15.1432 8 16.8 8Z" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4.80005 15C6.4569 15 7.80005 13.6569 7.80005 12C7.80005 10.3431 6.4569 9 4.80005 9C3.14319 9 1.80005 10.3431 1.80005 12C1.80005 13.6569 3.14319 15 4.80005 15Z" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.8 22C18.4569 22 19.8 20.6569 19.8 19C19.8 17.3431 18.4569 16 16.8 16C15.1432 16 13.8 17.3431 13.8 19C13.8 20.6569 15.1432 22 16.8 22Z" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.39001 13.51L14.22 17.49" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.21 6.51001L7.39001 10.49" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<filter id="filter0_b_401_390" x="-10" y="-10" width="44" height="44" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feGaussianBlur in="BackgroundImageFix" stdDeviation="5"/>
+<feComposite in2="SourceAlpha" operator="in" result="effect1_backgroundBlur_401_390"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_backgroundBlur_401_390" result="shape"/>
+</filter>
+</defs>
 </svg>

--- a/src/Components/Article/Content.jsx
+++ b/src/Components/Article/Content.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
+import { showDateForm } from '../../Utils/showDetailFunction';
 
 const Content = ({ data }) => {
   return (
@@ -11,7 +12,7 @@ const Content = ({ data }) => {
       <p>{data.GUNAME}</p>
       <h2>{data.TITLE} </h2>
       <p>{data.PLACE}</p>
-      <p>{data.DATE}</p>
+      <p>{showDateForm(data.STRTDATE, data.END_DATE)}</p>
     </SLink>
   );
 };

--- a/src/Components/Article/Content.jsx
+++ b/src/Components/Article/Content.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 
 const Content = ({ data }) => {
   return (
-    <SLink to="/ShowDetailPage">
+    <SLink to="/ShowDetailPage" state={data}>
       <div className="imgBox">
         <img src={data.MAIN_IMG} alt="포스터 이미지" />
       </div>

--- a/src/Components/Article/Content.jsx
+++ b/src/Components/Article/Content.jsx
@@ -39,8 +39,8 @@ const SLink = styled(Link)`
     /* 여러줄 다 보이기 */
     overflow: hidden;
     white-space: normal;
-    line-height: 1.2;
     display: -webkit-box;
+    line-height: 1.2;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
   }
@@ -48,6 +48,10 @@ const SLink = styled(Link)`
     font-size: 12px;
     margin-top: 5px;
     line-height: 1.2;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
     &:nth-child(2) {
       color: salmon;
     }

--- a/src/Components/Article/ShowDeatailTopBar.jsx
+++ b/src/Components/Article/ShowDeatailTopBar.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+import TopBarBtn from '../Common/TopBarBtn';
+import iconArrowWhite from '../../Assets/Icon/icon-arrow-white.svg';
+import iconShare from '../../Assets/Icon/icon-share.svg';
+
+const ShowDeatailTopBar = () => {
+  const navigate = useNavigate();
+  const handleClick = () => {
+    navigate(-1);
+  };
+
+  return (
+    <SShowDetailTopBar>
+      <div class="topBtns">
+        <TopBarBtn id="arrowWhite" icon={iconArrowWhite} altTxt={'뒤로가기'} onClick={handleClick} />
+        <TopBarBtn icon={iconShare} altTxt={'뒤로가기'} />
+      </div>
+    </SShowDetailTopBar>
+  );
+};
+
+export default ShowDeatailTopBar;
+
+const SShowDetailTopBar = styled.header`
+  z-index: 20;
+  margin-top: -48px;
+  position: fixed;
+  .topBtns {
+    width: 390px;
+    padding: 5px 10px 0 5px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    #arrowWhite {
+      width: 35px;
+      height: 35px;
+    }
+  }
+`;

--- a/src/Components/Article/ShowDetailInfo.jsx
+++ b/src/Components/Article/ShowDetailInfo.jsx
@@ -3,12 +3,12 @@ import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import Button from '../Common/Button';
 import Tags from '../Profile/Tags';
-import { showCodeName, showState, showDataTrim } from '../../Utils/showDetailFunction';
+import { showCodeName, showDateForm, showState, showDataTrim } from '../../Utils/showDetailFunction';
 
 const ShowDetailInfo = ({ detailData }) => {
   const detailDataArr = [
     { list: '신청일자', data: detailData.RGSTDATE },
-    { list: '공연일자', data: detailData.DATE },
+    { list: '공연일자', data: showDateForm(detailData.STRTDATE, detailData.END_DATE) },
     { list: '이용대상', data: detailData.USE_TRGT },
     { list: '이용요금', data: detailData.USE_FEE },
   ];

--- a/src/Components/Article/ShowDetailInfo.jsx
+++ b/src/Components/Article/ShowDetailInfo.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import Button from '../Common/Button';
+import Tags from '../Profile/Tags';
+import { showCodeName, showState, showDataTrim } from '../../Utils/showDetailFunction';
+
+const ShowDetailInfo = ({ detailData }) => {
+  const detailDataArr = [
+    { list: '신청일자', data: detailData.RGSTDATE },
+    { list: '공연일자', data: detailData.DATE },
+    { list: '이용대상', data: detailData.USE_TRGT },
+    { list: '이용요금', data: detailData.USE_FEE },
+  ];
+
+  return (
+    <SShowDtailInfo>
+      <h1 className="a11y-hidden">Show Dtail</h1>
+      <div className="tags">
+        <Tags text={showCodeName(detailData.CODENAME)} />
+        <Tags text={showState(detailData.STRTDATE, detailData.END_DATE)} />
+      </div>
+      <div class="info-txt">
+        <h2>{detailData.TITLE}</h2>
+        <p className="place">
+          {detailData.GUNAME} | {detailData.PLACE}
+        </p>
+        <ul>
+          {detailDataArr.map((data, i) => {
+            return (
+              <li key={i} i>
+                <p className="list">{data.list}</p>
+                <p>{showDataTrim(data.data)}</p>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+
+      <Link to={detailData.ORG_LINK}>
+        <Button size="Large">상세페이지 이동하기</Button>
+      </Link>
+    </SShowDtailInfo>
+  );
+};
+
+export default ShowDetailInfo;
+
+const SShowDtailInfo = styled.section`
+  z-index: 30;
+  width: 390px;
+  padding: 25px 34px 10px 34px;
+  background-color: #fff;
+  border-radius: 10px 10px 0 0;
+  box-shadow: 0 -10px 10px -10px rgba(0, 0, 0, 0.2);
+  position: fixed;
+  bottom: 60px;
+  .tags {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 5px;
+    text-align: center;
+    div .tags {
+      width: 100%;
+      background-color: var(--main);
+      color: white;
+      padding: 5px 10px;
+    }
+  }
+  .info-txt {
+    line-height: 1.3;
+    h2 {
+      font-size: 18px;
+      font-weight: 900;
+      margin-bottom: 10px;
+    }
+    .place {
+      border-bottom: 1px solid var(--gray);
+      padding-bottom: 15px;
+      margin-bottom: 20px;
+      font-size: 12px;
+    }
+    li {
+      display: flex;
+      margin-bottom: 10px;
+      font-size: 12px;
+      .list {
+        flex: 0 0 76px;
+        color: var(--deepgray);
+        &::after {
+          content: '|';
+          color: var(--gray);
+          margin: 0 15px;
+        }
+      }
+    }
+  }
+  button {
+    margin-top: 20px;
+  }
+`;

--- a/src/Components/Search/SearchContent.jsx
+++ b/src/Components/Search/SearchContent.jsx
@@ -9,7 +9,7 @@ const SearchContent = ({ data, keyword }) => {
   const afterStr = JSON.parse(chageStr);
 
   return (
-    <SLink to="/ShowDetailPage">
+    <SLink to="/ShowDetailPage" state={data}>
       <img src={data.MAIN_IMG} alt="포스터" />
       <div className="container">
         {/* 문자열을 html로 렌더링 해주는 속성 */}

--- a/src/Components/Search/SearchContent.jsx
+++ b/src/Components/Search/SearchContent.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
+import { showDateForm } from '../../Utils/showDetailFunction';
 
 const SearchContent = ({ data, keyword }) => {
   // 키워드 색상 변경을 위해 문자열로 변경 후 replace
@@ -17,7 +18,7 @@ const SearchContent = ({ data, keyword }) => {
         <p>
           {data.GUNAME} | {data.PLACE}
         </p>
-        <p>{data.DATE}</p>
+        <p>{showDateForm(data.STRTDATE, data.END_DATE)}</p>
       </div>
     </SLink>
   );
@@ -43,13 +44,7 @@ const SLink = styled(Link)`
       font-size: 14px;
       font-weight: 900;
       margin-top: 5px;
-      /* 여러줄 다 보이기 */
-      overflow: hidden;
-      white-space: normal;
       line-height: 1.2;
-      display: -webkit-box;
-      -webkit-line-clamp: 2;
-      -webkit-box-orient: vertical;
       span {
         color: var(--warning);
       }
@@ -58,6 +53,10 @@ const SLink = styled(Link)`
       font-size: 12px;
       margin-top: 5px;
       line-height: 1.2;
+      overflow: hidden;
+      display: -webkit-box;
+      -webkit-line-clamp: 1;
+      -webkit-box-orient: vertical;
       :nth-child(3) {
         color: grey;
       }

--- a/src/Pages/MainPage.jsx
+++ b/src/Pages/MainPage.jsx
@@ -25,6 +25,7 @@ const MainPage = () => {
   }, []);
 
   const showInfo = getShow.slice(1);
+  console.log(showInfo);
 
   return (
     <>

--- a/src/Pages/ShowDetailPage.jsx
+++ b/src/Pages/ShowDetailPage.jsx
@@ -1,50 +1,23 @@
 import React from 'react';
 import styled from 'styled-components';
+import { useLocation } from 'react-router-dom';
+import ShowDeatailTopBar from '../Components/Article/ShowDeatailTopBar';
+import ShowDetailInfo from '../Components/Article/ShowDetailInfo';
 import BottomNav from '../Components/Common/BottomNav';
-import Button from '../Components/Common/Button';
-import Tags from '../Components/Profile/Tags';
-import TopBarBtn from '../Components/Common/TopBarBtn';
-import iconArrowWhite from '../Assets/Icon/icon-arrow-white.svg';
-import iconShare from '../Assets/Icon/icon-share.svg';
-const imgSrc = 'https://culture.seoul.go.kr/cmmn/file/getImage.do?atchFileId=6a59720cd9c34bbfa056eb6b5031f809&thumb=Y';
 
-const ShowDetailPage = ({ props }) => {
-  const showInfo = [
-    { id: 1, title: '신청일자', data: '2023. 05. 18.' },
-    { id: 2, title: '공연일자', data: '2023.7. 2. ~ 2023. 8. 17.' },
-    { id: 3, title: '이용대상', data: '전체 연령 관람가' },
-    { id: 4, title: '이용요금', data: '일반 10,000원 / 어린이 및 학생 8,000원 등' },
-  ];
+const ShowDetailPage = () => {
+  const location = useLocation();
+  const detailData = location.state;
 
   return (
     <>
       <SShowDetail>
-        <header class="topBtns">
-          <TopBarBtn id="arrowWhite" icon={iconArrowWhite} altTxt={'뒤로가기'} />
-          <TopBarBtn icon={iconShare} altTxt={'뒤로가기'} />
-        </header>
-        <h1 className="a11y-hidden">Show Dtail</h1>
-        <div className="info">
-          <div className="tags">
-            <Tags text="전시/미술" />
-            <Tags text="공연예정" />
-          </div>
-          <div class="info-txt">
-            <h2>나루 큐브 프로젝트 [My Dear 피노키오展]</h2>
-            <p class="place">광진구 | 나루아트센터 전시실</p>
-            {showInfo.map(data => {
-              return (
-                <p>
-                  <span>{data.title}</span>
-                  {data.data}
-                </p>
-              );
-            })}
-          </div>
-          <a>
-            <Button size="Large">상세페이지 이동하기</Button>
-          </a>
+        <div className="shadowStyle" />
+        <ShowDeatailTopBar />
+        <div class="posterImg">
+          <img src={detailData.MAIN_IMG} alt="포스터" />
         </div>
+        <ShowDetailInfo detailData={detailData} />
       </SShowDetail>
       <BottomNav />
     </>
@@ -53,66 +26,22 @@ const ShowDetailPage = ({ props }) => {
 
 export default ShowDetailPage;
 
-const SShowDetail = styled.section`
-  flex: 1;
-  background: url(${imgSrc}) no-repeat center top / 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  .topBtns {
-    padding: 5px 10px 0 5px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    #arrowWhite {
-      width: 35px;
-      height: 35px;
-    }
+const SShowDetail = styled.div`
+  position: relative;
+  .shadowStyle {
+    z-index: 10;
+    width: 390px;
+    height: 70vh;
+    box-shadow: inset 0px 23px 35px rgba(0, 0, 0, 0.25);
+    position: absolute;
+    margin-top: -48px;
   }
-  .info {
-    padding: 30px 34px 10px 34px;
-    background-color: #fff;
-    border-radius: 10px 10px 0 0;
-    .tags {
-      display: flex;
-      gap: 10px;
-      margin-bottom: 10px;
-      text-align: center;
-      div {
-        div {
-          background-color: var(--main);
-          color: white;
-          margin: 0 auto;
-        }
-      }
-    }
-    .info-txt {
-      /* margin-bottom: 30px; */
-      h2 {
-        font-size: 18px;
-        font-weight: bold;
-        margin-bottom: 15px;
-      }
-      .place {
-        border-bottom: 1px solid var(--gray);
-        padding-bottom: 20px;
-        margin-bottom: 20px;
-      }
-      p {
-        margin-bottom: 10px;
-        font-size: 12px;
-        span {
-          color: var(--deepgray);
-          &::after {
-            content: '|';
-            color: var(--gray);
-            margin: 0 15px;
-          }
-        }
-      }
-      &:nth-child(2) {
-        margin-bottom: 30px;
-      }
+  .posterImg {
+    background-color: #000;
+    height: 70vh;
+    img {
+      width: 390px;
+      margin-top: -48px;
     }
   }
 `;

--- a/src/Utils/showDetailFunction.jsx
+++ b/src/Utils/showDetailFunction.jsx
@@ -1,0 +1,46 @@
+// (참고) 공공 API 데이터 형식
+// CODENAME: "클래식"
+// DATE: "2023-12-05~2023-12-05"
+// END_DATE: "2023-12-05 00:00:00.0"
+// ETC_DESC: ""
+// GUNAME: "마포구"
+// MAIN_IMG: "https://culture.seoul.go.kr/cmmn/file/getImage.do?atchFileId=6a59720cd9c34bbfa056eb6b5031f809&thumb=Y"
+// ORG_LINK: "https://www.mfac.or.kr/performance/whole_view.jsp?sc_b_category=17&sc_b_code=BOARD_1207683401&pk_seq=2176&page=1"
+// ORG_NAME: ""
+// PLACE: "마포아트센터 아트홀맥"
+// PLAYER: "피아니스트 김도현"
+// PROGRAM: ""
+// RGSTDATE: "2023-03-15"
+// STRTDATE: "2023-12-05 00:00:00.0"
+// THEMECODE: "기타"
+// TICKET: "기관"
+// TITLE: " M 아티스트 2023 김도현 피아노 리사이틀 II"
+// USE_FEE: " VIP석 55,000원, R석 44,000원, S석 33,000원"
+// USE_TRGT: " 8세이상관람가[미취학아동입장불가]"
+
+// 공연 카테고리 확인 함수 : '축제' 단어 포함 시 축제 반환
+export const showCodeName = codename => {
+  return codename.includes('축제') ? '축제' : codename;
+};
+
+// 공연 날짜 확인 함수
+export const showDateForm = (startDate, endDate) => {
+  let startDateForm = startDate.split(' ')[0];
+  let endDateForm = endDate.split(' ')[0];
+
+  if (startDateForm === endDateForm) return startDateForm;
+  else return startDateForm + '~' + endDateForm;
+};
+
+// 공연 상태 확인 함수
+export const showState = (startDate, endDate) => {
+  // 오늘 날짜 확인 - 반환 데이터 형식 : '2023-00-00'
+  const today = new Date().toISOString().slice(0, 10);
+
+  return today < startDate ? '공연예정' : today > endDate ? '공연종료' : '공연중';
+};
+
+// 정보가 null이면 '정보없음' 반환, 데이터 앞 공백 제거하는 함수
+export const showDataTrim = showData => {
+  return showData === null ? '정보없음' : showData.replace(/^\s+/g, '');
+};

--- a/src/Utils/showDetailFunction.jsx
+++ b/src/Utils/showDetailFunction.jsx
@@ -42,5 +42,5 @@ export const showState = (startDate, endDate) => {
 
 // 정보가 null이면 '정보없음' 반환, 데이터 앞 공백 제거하는 함수
 export const showDataTrim = showData => {
-  return showData === null ? '정보없음' : showData.replace(/^\s+/g, '');
+  return showData === '' ? '정보없음' : showData.replace(/^\s+/g, '');
 };


### PR DESCRIPTION
### 행사상세페이지
- 마크업 초안 완료
- 공유 아이콘 색상 변경 (svg 파일 수정)
- 메인페이지, 검색페이지에서 클릭한 컨텐츠 데이터 불러옴
- 공공 API 데이터 형식 가공 함수 정의 및 활용 -> Utils 폴더 생성해서 넣어놨습니다!
- 행사상세페이지 컴포넌트 분리

### 이슈
행사상세페이지 링크로 바로 접속시엔 에러발생 -> 메인페이지, 검색페이지를 통해서만 페이지접속 가능