### PR TITLE
[Feat] 프로필 수정 페이지에서 기존 계정 이름과 동일할때 처리

### DIFF
--- a/src/Components/Common/ProfileImageEdit.jsx
+++ b/src/Components/Common/ProfileImageEdit.jsx
@@ -36,7 +36,7 @@ const SProfileImageEdit = styled.div`
   img {
     width: 130px;
     height: 130px;
-    object-fit: fill;
+    object-fit: cover;
     border-radius: 50%;
   }
 
@@ -48,7 +48,6 @@ const SProfileImageEdit = styled.div`
     .upload-label {
       cursor: pointer;
       img {
-        object-fit: fill;
         width: 40px;
         height: 40px;
       }

--- a/src/Components/Common/ProfileInfoEdit.jsx
+++ b/src/Components/Common/ProfileInfoEdit.jsx
@@ -3,19 +3,27 @@ import styled from 'styled-components';
 import ProfileImageEdit from './ProfileImageEdit';
 import InputBox from './InputBox';
 import ProfileInterests from '../Profile/ProfileInterests';
-import { InfoWarning } from '../../Atom/atom';
+import { InfoWarning, MyAccountName } from '../../Atom/atom';
 import { useRecoilValue } from 'recoil';
 import { IsValidAccountAPI } from '../../API/User';
 
 const ProfileInfoEdit = ({ introGenerator, setIsValidInputs, profile, setProfile }) => {
-  const [validAccountName, setValidAccountName] = useState(false);
-  const [validUserName, setValidUserName] = useState(false);
+  const [validAccountName, setValidAccountName] = useState(true);
+  const [validUserName, setValidUserName] = useState(true);
   const [userNameFailedMsg, setUserNameFailedMsg] = useState('');
   const [AccountnameFailedMsg, setAccountnameFailedMsg] = useState('');
   const warning = useRecoilValue(InfoWarning);
+  const myAccountName = useRecoilValue(MyAccountName);
 
   const isValidAccountName = async () => {
-    const regExp = /^[a-zA-Z0-9_\.]*$/;
+    const regExp = /^[a-zA-Z0-9_.]*$/;
+
+    if (myAccountName === profile.accountname) {
+      setValidAccountName(true);
+      setAccountnameFailedMsg('');
+      return;
+    }
+
     if (!regExp.test(profile.accountname)) {
       setValidAccountName(false);
       setAccountnameFailedMsg('영문, 숫자, 특수문자(_),(.)만 사용 가능합니다.');
@@ -42,12 +50,9 @@ const ProfileInfoEdit = ({ introGenerator, setIsValidInputs, profile, setProfile
   };
 
   useEffect(() => {
-    console.log('123123');
     if (validAccountName && validUserName) {
-      console.log('456');
       setIsValidInputs(true);
     } else {
-      console.log('789');
       setIsValidInputs(false);
     }
   }, [validAccountName, validUserName]);

--- a/src/Pages/ProfileEditPage.jsx
+++ b/src/Pages/ProfileEditPage.jsx
@@ -64,16 +64,16 @@ const ProfileEditPage = () => {
   };
 
   useEffect(() => {
-    console.log('!!!!!!!!!!!!!!!!!!2222');
     if (isValidInputs) {
       setBtnAble(true);
-    } else setBtnAble(false);
+    } else {
+      setBtnAble(false);
+    }
   }, [isValidInputs]);
 
   useEffect(() => {
     getProfile();
-    console.log('!!!!!!!!!!!!!!!!!!!!1');
-    // setBtnAble(true);
+    setIsValidInputs(true);
   }, []);
 
   return (


### PR DESCRIPTION
- 기존 계정 이름과 동일할때 저장 가능하게
- 다른 이름으로 수정했다가 기존 계정 이름과 동일하게 다시 작성해도 저장 가능
- profile image : object-fit: cover