### PR TITLE
[Fix] 댓글 / 게시글 삭제 렌더링

### DIFF
--- a/src/Components/Common/Post/PostContent.jsx
+++ b/src/Components/Common/Post/PostContent.jsx
@@ -118,6 +118,7 @@ const SPostContentA = styled.a`
       width: 160px;
       object-fit: cover;
       border-radius: 20px;
+      box-shadow: rgba(50, 50, 93, 0.25) 0px 2px 5px -1px, rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
     }
   }
 `;

--- a/src/Components/Common/Post/PostHeader.jsx
+++ b/src/Components/Common/Post/PostHeader.jsx
@@ -44,6 +44,8 @@ const PostHeader = ({ postsData }) => {
       closeModal();
     } catch (e) {
       console.error(e);
+    } finally {
+      navigate('/postpage');
     }
   };
 

--- a/src/Components/Common/Post/PostHeader.jsx
+++ b/src/Components/Common/Post/PostHeader.jsx
@@ -123,6 +123,7 @@ const SPostHeaderDiv = styled.div`
       width: 42px;
       height: 42px;
       border-radius: 50%;
+      object-fit: cover;
     }
     // 게시물 작성자 이름과 아이디 감싼거
     div {

--- a/src/Components/Common/Post/PostHeader.jsx
+++ b/src/Components/Common/Post/PostHeader.jsx
@@ -80,7 +80,10 @@ const PostHeader = ({ postsData }) => {
           <img src={postsData.author.image} alt="" />
           <div>
             <SPostUserName>{username}</SPostUserName>
-            <SPostUserId>{accountname}</SPostUserId>
+            <SPostUserId>
+              <span>@_</span>
+              {accountname}
+            </SPostUserId>
           </div>
         </Link>
         {accountname === getMyAccounName ? (

--- a/src/Components/Common/Post/PostLayoutButtons.jsx
+++ b/src/Components/Common/Post/PostLayoutButtons.jsx
@@ -25,7 +25,6 @@ const SLayoutButtons = styled.div`
     flex-grow: 1;
     flex-basis: auto;
     border-top: 1px solid var(--gray);
-    border-bottom: 1px solid var(--gray);
     box-sizing: border-box;
   }
 `;
@@ -33,9 +32,11 @@ const SLayoutButtons = styled.div`
 const SListButton = styled.button`
   border-right: 1px solid var(--gray);
   background: url(${ListOn}) no-repeat center;
+  border-bottom: 1px solid var(--deepgray);
 `;
 
 const SGridButton = styled.button`
   border-left: none;
   background: url(${AlbumOff}) no-repeat center;
+  border-bottom: 1px solid var(--gray);
 `;

--- a/src/Components/Common/Profile.jsx
+++ b/src/Components/Common/Profile.jsx
@@ -65,6 +65,7 @@ const SProfileSection = styled.section`
     height: 90px;
     border-radius: 50%;
     margin: 30px auto 0;
+    object-fit: cover;
   }
   // 프로필 관심 목록
   div {

--- a/src/Components/Common/Profile.jsx
+++ b/src/Components/Common/Profile.jsx
@@ -31,7 +31,10 @@ const Profile = ({ accountname }) => {
           <img src={profileData.image} alt=""></img>
         )}
         <SProfileName>{profileData.username}</SProfileName>
-        <SProfileId>{profileData.accountname}</SProfileId>
+        <SProfileId>
+          <span>@_</span>
+          {profileData.accountname}
+        </SProfileId>
 
         {/* api에서 들고오는 관심 리스트 묶어주는 div   */}
         <div>

--- a/src/Components/Post/Comments.jsx
+++ b/src/Components/Post/Comments.jsx
@@ -11,11 +11,8 @@ const Comments = ({ postsComments, postsId, postsData }) => {
   const commentId = postsComments.id;
   const URL = 'https://api.mandarin.weniv.co.kr';
   const getMyToken = useRecoilValue(Token);
-  const navigate = useNavigate();
   const getMyAccountName = useRecoilValue(MyAccountName);
   const commentAccountName = postsComments.author.accountname;
-
-  // 댓글 모달 연결
 
   // 댓글 삭제 기능
   const DeleteComment = async () => {
@@ -35,6 +32,7 @@ const Comments = ({ postsComments, postsId, postsData }) => {
     }
   };
 
+  // 댓글 모달 연결
   const [isOtherSModalVisible, setIsOtherSModalVisible] = useState(false);
   const [isSModalVisible, setIsSModalVisible] = useState(false);
   // 댓글이 내 거일때 열어주는 모달
@@ -109,6 +107,7 @@ const SComments = styled.div`
     width: 36px;
     height: 36px;
     border-radius: 50%;
+    object-fit: cover;
   }
 
   .comment-title {

--- a/src/Components/Post/Comments.jsx
+++ b/src/Components/Post/Comments.jsx
@@ -13,7 +13,7 @@ const Comments = ({ postsComments, postsId, postsData }) => {
   const getMyToken = useRecoilValue(Token);
   const getMyAccountName = useRecoilValue(MyAccountName);
   const commentAccountName = postsComments.author.accountname;
-
+  const navigate = useNavigate();
   // 댓글 삭제 기능
   const DeleteComment = async () => {
     try {
@@ -29,6 +29,8 @@ const Comments = ({ postsComments, postsId, postsData }) => {
       setIsSModalVisible(false);
     } catch (error) {
       console.error(error);
+    } finally {
+      navigate('/postdetailpage', { state: postsData });
     }
   };
 

--- a/src/Components/Post/CommentsForm.jsx
+++ b/src/Components/Post/CommentsForm.jsx
@@ -1,17 +1,36 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
-import { Token } from '../../Atom/atom';
+import { Token, MyAccountName } from '../../Atom/atom';
 import { useNavigate } from 'react-router-dom';
-
-// assets
-import LogoGraySmall from '../../Assets/Icon/logo-gray-small.svg';
 
 const CommentsForm = ({ postsId, postsData }) => {
   const URL = 'https://api.mandarin.weniv.co.kr';
   const getMyToken = useRecoilValue(Token);
+  const getMyAccountName = useRecoilValue(MyAccountName);
   const [textareaValue, setTextareaValue] = useState('');
   const textRef = useRef();
   const navigate = useNavigate();
+  const [pI, setPI] = useState('');
+  const myProfileImg = async () => {
+    try {
+      const req = {
+        method: 'GET',
+        headers: {
+          'Content-type': 'application/json',
+          Authorization: 'Bearer ' + getMyToken,
+        },
+      };
+      const response = await fetch(URL + '/profile/' + getMyAccountName, req);
+      const data = await response.json();
+      // console.log(data.profile.image);
+      setPI(data.profile.image);
+      return data;
+    } catch (e) {
+      console.error(e);
+    }
+  };
+  myProfileImg();
+  // console.log(pI);
 
   const handleInputChange = e => {
     setTextareaValue(e.target.value);
@@ -44,7 +63,7 @@ const CommentsForm = ({ postsId, postsData }) => {
   };
   return (
     <>
-      <img src={LogoGraySmall} alt="" />
+      <img src={pI} alt="" />
       <form>
         <textarea onChange={handleInputChange} ref={textRef} required placeholder="댓글 입력하기..."></textarea>
 

--- a/src/Pages/PostDetailPage.jsx
+++ b/src/Pages/PostDetailPage.jsx
@@ -72,8 +72,8 @@ const PostDetailPage = () => {
         </SCommentsWrapper>
       </SPostDetailContent>
       <SContainer>
-        <SCommentDiv name="" action="" method="">
-          <CommentsForm postsData={getPostsData} postsId={postsId} />
+        <SCommentDiv>
+          <CommentsForm postsComments={postsComments} postsData={getPostsData} postsId={postsId} />
         </SCommentDiv>
       </SContainer>
     </>
@@ -153,6 +153,8 @@ const SCommentDiv = styled.div`
     width: 36px;
     height: 36px;
     margin-left: 16px;
+    object-fit: cover;
+    border-radius: 50%;
   }
   form {
     margin-left: 18px;

--- a/src/Pages/PostDetailPage.jsx
+++ b/src/Pages/PostDetailPage.jsx
@@ -135,7 +135,7 @@ const SContainer = styled.div`
 
 const SCommentsWrapper = styled.div`
   border-top: 2px solid #dbdbdb;
-  padding: 12px 16px;
+  padding: 12px 16px 18px;
   width: 390px;
 `;
 

--- a/src/Pages/PostPage.jsx
+++ b/src/Pages/PostPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
+import { useLocation } from 'react-router-dom';
 
 // 공통 컴포넌트
 import TopBar from '../Components/Common/TopBar';

--- a/src/Pages/PostPage.jsx
+++ b/src/Pages/PostPage.jsx
@@ -36,7 +36,7 @@ const PostPage = () => {
               'Bearer ' + getAdminToken,
           },
         };
-        const response = await fetch(URL + '/post/feed', req);
+        const response = await fetch(URL + '/post/feed/?limit=100', req);
         const data = await response.json();
         setFeedData(data.posts);
         if (!response.ok) throw new Error('내가 팔로우 하는 유저들 게시글 불러오기 에러');

--- a/src/Pages/PostingPage.jsx
+++ b/src/Pages/PostingPage.jsx
@@ -125,7 +125,7 @@ const SPostingContent = styled.div`
   .uploadBtn {
     position: fixed;
     top: 8px;
-    margin-left: 268px;
+    margin-left: 278px;
     background-color: var(--main);
     color: white;
     width: 90px;


### PR DESCRIPTION
- 댓글 삭제시 화면에 즉시 반영 안되는 오류 수정
- 게시글 상세 페이지에서 게시글 삭제시 게시글 피드 페이지로 이동하면서 반영됨
- 게시글 피드 페이지에서 바로 게시글 삭제하면 바로 반영되지 않고 새로고침 해야됨 (수정예정)

 그 외
- 유저 프로필 이미지에 cover값과 border-radius 50%
- 포스팅 페이지 업로드 버튼 위치 조절
- 게시글 이미지 박스 쉐도우 적용
- 댓글 전체 감싸는 div에 패딩값 